### PR TITLE
Fix: Download punkt_tab NLTK resource to resolve LookupError

### DIFF
--- a/story_analyzer_demo.py
+++ b/story_analyzer_demo.py
@@ -178,7 +178,7 @@ try:
     import nltk
     
     # Download all required NLTK data
-    required_nltk_data = ['punkt', 'stopwords']
+    required_nltk_data = ['punkt', 'stopwords', 'punkt_tab']
     
     for data in required_nltk_data:
         try:


### PR DESCRIPTION
The script was failing with a LookupError because the 'punkt_tab' NLTK resource was missing. This resource is required by nltk.sent_tokenize for certain text structures.

This commit updates the NLTK data initialization logic to include 'punkt_tab' in the list of required resources to be downloaded if not found. The existing error handling mechanisms are sufficient to cover potential issues during the download process.