### PR TITLE
Feat: Embed locally running Streamlit demos

### DIFF
--- a/tensorus-demo-page/README.md
+++ b/tensorus-demo-page/README.md
@@ -6,10 +6,12 @@ This is the frontend application for showcasing conceptual demos of **Tensorus**
 
 *   **Demo Gallery:** A home page displaying all available Tensorus demos in a card-based layout.
 *   **Detailed Demo Pages:** Individual pages for each demo, providing:
+    *   Clear instructions on how to run the specific Streamlit demo locally.
+    *   An embedded `iframe` to display the locally running Streamlit application.
     *   A comprehensive description.
     *   Key features and concepts highlighted.
-    *   Placeholder for visuals (screenshots/videos).
-    *   Links to the demo's source code or specific README for execution instructions.
+    *   Links to the demo's source code or specific README for full setup details.
+*   **Embedded Local Demos:** Interactive Streamlit demos are embedded directly. Users need to run the Streamlit applications locally for them to appear in the gallery.
 *   **Clean, Responsive Design:** Styled for a clean, modern aesthetic with basic responsiveness for different screen sizes.
 *   **Scalable:** Designed to easily accommodate new demos in the future.
 

--- a/tensorus-demo-page/src/demoData.js
+++ b/tensorus-demo-page/src/demoData.js
@@ -1,14 +1,12 @@
-// Placeholder image URLs can be updated later with actual screenshots or relevant visuals
-// For now, using generic placeholders from placehold.co for better visual variety.
-
+// tensorus-demo-page/src/demoData.js
 export const demos = [
   {
     id: 'financial-news-impact',
     title: 'Financial News Impact Demo',
     shortDescription: 'Illustrates using multi-modal context for predicting financial news impact with RAG.',
     longDescription: 'This demo showcases how Tensorus can provide richer, multi-modal context for AI models to predict the impact of financial news on a network of assets. It contrasts the Tensorus approach (using multiple, structured tensors per news event) with traditional vector database approaches (using a single embedding per event) for Retrieval Augmented Generation (RAG). The goal is to show how more comprehensive data can lead to better informed inputs for hypothetical downstream predictive models.',
-    thumbnailUrl: 'https://placehold.co/600x360/007AFF/FFFFFF/png?text=Financial+Demo', // Apple Blue background
-    visualsPath: 'https://placehold.co/800x450/007AFF/FFFFFF/png?text=Financial+News+Impact+Detail',
+    thumbnailUrl: 'https://placehold.co/600x360/007AFF/FFFFFF/png?text=Financial+Demo',
+    visualsPath: 'https://placehold.co/800x450/007AFF/FFFFFF/png?text=Financial+News+Impact+Detail', // Placeholder for actual screenshot of the demo page
     keyFeatures: [
       'Storing multi-modal data (news text, market features, sentiment scores) as distinct, yet related, tensors.',
       'Enabling Retrieval Augmented Generation (RAG) with rich, multi-faceted tensor context.',
@@ -16,23 +14,27 @@ export const demos = [
       'Facilitating more informed inputs for hypothetical downstream predictive models.'
     ],
     readmeLink: 'https://github.com/GoogleCloudPlatform/tensorus/blob/main/README_financial_news_impact_demo.md',
-    tags: ['Finance', 'RAG', 'Multi-modal', 'NLP']
+    tags: ['Finance', 'RAG', 'Multi-modal', 'NLP'],
+    localPort: 8501, // Default Streamlit port
+    streamlitCommand: 'streamlit run financial_news_impact_demo.py'
   },
   {
     id: 'smart-story-analyzer',
     title: 'Smart Story Analyzer Demo',
     shortDescription: 'Analyzes character relationships and sentiment evolution in literary texts using tensor representations.',
     longDescription: 'This demo highlights how Tensorus can be used to analyze character relationships and sentiment evolution within literary texts. It processes story snippets, stores various analytical representations as tensors (like sentence embeddings, character-specific sentiment flows, and interaction matrices), and allows users to explore how character dynamics change throughout the narrative. It emphasizes storing and retrieving complex relational data that AI agents can easily process for insights.',
-    thumbnailUrl: 'https://placehold.co/600x360/34C759/FFFFFF/png?text=Story+Analyzer', // Apple Green background
-    visualsPath: 'https://placehold.co/800x450/34C759/FFFFFF/png?text=Smart+Story+Analyzer+Detail',
+    thumbnailUrl: 'https://placehold.co/600x360/34C759/FFFFFF/png?text=Story+Analyzer',
+    visualsPath: 'https://placehold.co/800x450/34C759/FFFFFF/png?text=Smart+Story+Analyzer+Detail', // Placeholder for actual screenshot of the demo page
     keyFeatures: [
-      'Transforming textual narratives into multiple structured tensors.',
+      'Transforms textual narratives into multiple structured tensors.',
       'Analyzing the temporal evolution of relationships and sentiments by operating on sequences of tensors.',
       'Enabling more nuanced queries about character dynamics beyond simple keyword searches.',
       'Storing and retrieving complex relational data for AI agents.'
     ],
     readmeLink: 'https://github.com/GoogleCloudPlatform/tensorus/blob/main/README_story_analyzer_demo.md',
-    tags: ['NLP', 'Literature', 'Sentiment Analysis', 'Relationships']
+    tags: ['NLP', 'Literature', 'Sentiment Analysis', 'Relationships'],
+    localPort: 8501, // Default Streamlit port (Note: if running both simultaneously, one will take another port like 8502)
+    streamlitCommand: 'streamlit run story_analyzer_demo.py'
   }
   // Future demos will be added here
 ];

--- a/tensorus-demo-page/src/pages/DemoPage.css
+++ b/tensorus-demo-page/src/pages/DemoPage.css
@@ -91,9 +91,8 @@
     font-weight: 500;
 }
 
-.demo-cta {
+.demo-cta { /* This class is still used by a section wrapper in DemoPage.jsx */
   text-align: center;
-  /* padding: 2rem 0; Removed as demo-section now has padding */
 }
 
 .cta-button {
@@ -136,5 +135,98 @@
   }
   .demo-section {
     padding: 1rem; /* Reduce padding within sections */
+  }
+}
+
+.demo-instructions {
+  background-color: #f0f7ff; /* Light blue */
+  border: 1px solid #b3d7ff; /* Slightly darker border for better definition */
+  padding: 1.5rem;
+  border-radius: 8px;
+  margin-bottom: 2rem;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.05); /* Add a very subtle shadow */
+}
+
+.demo-instructions h3 {
+  color: #004a99; /* Even darker blue for more contrast */
+  margin-top: 0;
+  font-size: 1.3rem; /* Ensure it's prominent */
+}
+
+.demo-instructions ol {
+  padding-left: 25px; /* Ensure enough space for numbers */
+  margin-top: 1rem;
+}
+
+.demo-instructions li {
+  margin-bottom: 0.85rem; /* Slightly more spacing */
+  line-height: 1.6;
+  color: #222; /* Darker text for better readability */
+}
+
+.demo-instructions pre {
+  background-color: #000000; /* Black background for command */
+  color: #f0f0f0; /* Light text for command */
+  padding: 1rem 1.25rem; /* More padding */
+  border-radius: 6px; /* Slightly more rounded */
+  overflow-x: auto;
+  margin-top: 0.75rem; /* Adjusted margin */
+  margin-bottom: 0.75rem; /* Adjusted margin */
+  box-shadow: inset 0 1px 3px rgba(0,0,0,0.3);
+}
+
+.demo-instructions code {
+  font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, Courier, monospace;
+  font-size: 0.95rem; /* Slightly larger for readability */
+  color: #f0f0f0; /* Match pre text color */
+  background-color: transparent; /* Ensure no other background is inherited */
+}
+
+.demo-embed .iframe-container {
+  border: 1px solid #ccc; /* Slightly darker border for iframe */
+  border-radius: 8px;
+  overflow: hidden;
+  margin-top: 1rem;
+  min-height: 700px;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.1); /* More distinct shadow for the iframe container */
+}
+
+.demo-embed iframe {
+  border: none;
+  display: block;
+  width: 100%;
+  height: 700px;
+}
+
+.embed-note, .visuals-note { /* Common styling for notes */
+    font-size: 0.9rem; /* Slightly larger */
+    color: #444; /* Darker grey for more importance */
+    text-align: center;
+    margin-top: 1rem; /* Increased margin */
+    padding: 0.75rem; /* More padding */
+    background-color: #f9f9f9; /* Slightly off-white */
+    border-radius: 6px; /* More rounded */
+    border: 1px solid #eee;
+}
+
+.demo-source-code-cta { /* Renamed from demo-cta for clarity */
+  text-align: center;
+}
+
+/* Adjust section order if needed, e.g., move visuals below description */
+.demo-description { order: 1; }
+.demo-visuals { order: 2; } /* Example: if you want visuals after description */
+.demo-features { order: 3; }
+/* ... etc. if you want to re-order sections using flexbox on the parent */
+
+@media (max-width: 600px) {
+  .demo-instructions pre code {
+    font-size: 0.85rem;
+  }
+  .demo-embed iframe {
+    height: 500px; /* Reduce height on smaller screens */
+  }
+  .demo-embed .iframe-container {
+    min-height: 500px;
   }
 }

--- a/tensorus-demo-page/src/pages/DemoPage.jsx
+++ b/tensorus-demo-page/src/pages/DemoPage.jsx
@@ -1,16 +1,15 @@
 import React from 'react';
 import { useParams, Link } from 'react-router-dom';
-import { demos } from '../demoData'; // Import data from the new file
+import { demos } from '../demoData';
 import './DemoPage.css';
 
 const DemoPage = () => {
   const { demoId } = useParams();
-  // Find the demo data by id
   const demo = demos.find(d => d.id === demoId);
 
   if (!demo) {
     return (
-      <div className="demo-page-container"> {/* Added a container for consistent centering */}
+      <div className="demo-page-container">
         <div className="demo-page not-found-page">
           <h2>Demo Not Found</h2>
           <p>The demo you are looking for (ID: {demoId}) does not exist.</p>
@@ -20,6 +19,8 @@ const DemoPage = () => {
     );
   }
 
+  const streamlitAppUrl = `http://localhost:${demo.localPort || 8501}`;
+
   return (
     <div className="demo-page-container">
       <div className="demo-page">
@@ -27,14 +28,44 @@ const DemoPage = () => {
           <h1>{demo.title}</h1>
         </header>
 
+        <section className="demo-section demo-instructions">
+          <h3>Running the Demo Locally</h3>
+          <p>This demo is an interactive Streamlit application that runs on your local machine. To view and interact with it below, please follow these steps:</p>
+          <ol>
+            <li>Open your terminal or command prompt.</li>
+            <li>Navigate to the root directory of the 'tensorus' project (the one containing the demo's Python file).</li>
+            <li>
+              Run the following command:
+              <pre><code>{demo.streamlitCommand}</code></pre>
+            </li>
+            <li>Once the Streamlit app is running (usually it will also open in a new browser tab), it should appear in the embedded frame below.</li>
+            <li>If the port {demo.localPort || 8501} is already in use by another application, Streamlit might choose the next available port (e.g., 8502). The embed below targets port {demo.localPort || 8501}. For now, please ensure this demo runs on the target port or stop other Streamlit apps.</li>
+          </ol>
+        </section>
+
+        <section className="demo-section demo-embed">
+          <h3>Live Demo</h3>
+          <div className="iframe-container">
+            <iframe
+              src={streamlitAppUrl}
+              title={`${demo.title} - Live Streamlit Demo`}
+              width="100%"
+              height="700px" // Initial height, can be adjusted with CSS
+              allow="cross-origin-isolated" // May or may not be needed
+            ></iframe>
+          </div>
+           <p className="embed-note">Note: The embedded demo above requires the Streamlit application to be running locally on your machine as per the instructions.</p>
+        </section>
+
         <section className="demo-section demo-description">
           <h3>Overview</h3>
           <p>{demo.longDescription}</p>
         </section>
 
         <section className="demo-section demo-visuals">
-          <h3>Visual Showcase</h3>
+          <h3>Conceptual Visuals / Screenshots</h3>
           <img src={demo.visualsPath} alt={`${demo.title} Visual Representation`} />
+          <p className="visuals-note">This is a static visual. The interactive demo is above.</p>
         </section>
 
         <section className="demo-section demo-features">
@@ -53,9 +84,9 @@ const DemoPage = () => {
           </div>
         </div>
 
-        <section className="demo-section demo-cta">
+        <section className="demo-section demo-source-code-cta">
           <a href={demo.readmeLink} target="_blank" rel="noopener noreferrer" className="cta-button">
-            View on GitHub & Run Demo (README)
+            View Source & Full Setup (README)
           </a>
         </section>
 


### PR DESCRIPTION
This commit updates the Tensorus Demo Gallery to embed Streamlit demos directly into the demo detail pages.

Key changes:
- I modified `demoData.js` to include `localPort` and `streamlitCommand` for each demo, facilitating local execution and embedding.
- I updated `DemoPage.jsx` to:
    - Display clear instructions for you on how to run the specific Streamlit demo locally.
    - Include an `<iframe>` that points to the configured local Streamlit port (e.g., http://localhost:8501).
    - Change the main call-to-action button to "View Source & Full Setup (README)".
- I enhanced `DemoPage.css` with styles for the instruction block and the iframe container, ensuring a clean and user-friendly presentation.
- I updated `tensorus-demo-page/README.md` to reflect that demos are embedded from locally running instances.
- I created a manual test plan (as part of the development process) to verify the new embedding functionality.

This change significantly improves your experience by allowing direct interaction with demos within the gallery, assuming you have the corresponding Streamlit application running locally.