### PR TITLE
Add simple MCP time series demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,11 @@ Here's an overview of the sample applications you can explore:
     *   Storing and retrieving complex relational data (like character interactions and sentiments) in a way that AI agents can easily process for insights.
 *   **How to Run:** For detailed prerequisites, setup, and execution instructions, please see:
     *   ➡️ **[Details and Setup Instructions](README_story_analyzer_demo.md)**
+### 3. MCP Time Series Demo
+
+*   **Description:** Demonstrates the Tensorus MCP server and client with a simple time series dataset. The demo inserts a synthetic sine wave using MCP calls and retrieves it back.
+*   **How to Run:** See ➡️ **[README_mcp_time_series_demo.md](README_mcp_time_series_demo.md)**
+
 
 ---
 

--- a/README_mcp_time_series_demo.md
+++ b/README_mcp_time_series_demo.md
@@ -1,0 +1,28 @@
+# Tensorus MCP Time Series Demo
+
+This small example demonstrates how to use the Model Context Protocol (MCP) server and client from [Tensorus](https://github.com/tensorus/tensorus) to store and retrieve simple time series data.
+
+The demo uses a minimal FastAPI backend with an in-memory tensor store. The MCP server exposes this backend as standard MCP tools and the client communicates with it over a stdio transport.
+
+## Prerequisites
+
+* Python 3.8+
+* Install dependencies:
+  ```bash
+  pip install -r requirements.txt fastmcp uvicorn numpy
+  ```
+
+## Running the Demo
+
+1. **Start the server** (this runs both the API and MCP server):
+   ```bash
+   python mcp_time_series_server.py
+   ```
+   Leave this running in a terminal.
+
+2. **Run the client demo** in another terminal:
+   ```bash
+   python mcp_time_series_demo.py
+   ```
+
+The client creates a dataset, inserts a synthetic sine wave, lists available datasets, and fetches the stored tensor via the MCP server. This illustrates how Tensorus capabilities can be accessed through the standardized MCP interface.

--- a/mcp_time_series_demo.py
+++ b/mcp_time_series_demo.py
@@ -1,0 +1,94 @@
+import asyncio
+import json
+import math
+import os
+from dataclasses import dataclass
+from typing import Any, Optional, Sequence
+
+import numpy as np
+from fastmcp.client import Client as FastMCPClient, StdioTransport
+try:
+    from fastmcp.tools import TextContent
+except Exception:  # pragma: no cover - minimal fallback
+    @dataclass
+    class TextContent:  # type: ignore
+        type: str
+        text: str
+
+
+class TensorusMCPClient:
+    """High level client for the Tensorus MCP server."""
+
+    def __init__(self, transport: Any) -> None:
+        self._client = FastMCPClient(transport)
+
+    async def __aenter__(self) -> "TensorusMCPClient":
+        await self._client.__aenter__()
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        await self._client.__aexit__(exc_type, exc, tb)
+
+    async def _call_json(self, name: str, arguments: Optional[dict] = None) -> Any:
+        result = await self._client.call_tool(name, arguments or {})
+        if not result:
+            return None
+        content = result[0]
+        if isinstance(content, TextContent):
+            return json.loads(content.text)
+        raise TypeError("Unexpected content type")
+
+    async def list_datasets(self) -> Any:
+        return await self._call_json("tensorus_list_datasets")
+
+    async def create_dataset(self, dataset_name: str) -> Any:
+        return await self._call_json("tensorus_create_dataset", {"dataset_name": dataset_name})
+
+    async def ingest_tensor(
+        self,
+        dataset_name: str,
+        tensor_shape: Sequence[int],
+        tensor_dtype: str,
+        tensor_data: Any,
+        metadata: Optional[dict] = None,
+    ) -> Any:
+        payload = {
+            "dataset_name": dataset_name,
+            "tensor_shape": list(tensor_shape),
+            "tensor_dtype": tensor_dtype,
+            "tensor_data": tensor_data,
+            "metadata": metadata,
+        }
+        return await self._call_json("tensorus_ingest_tensor", payload)
+
+    async def get_tensor_details(self, dataset_name: str, record_id: str) -> Any:
+        return await self._call_json(
+            "tensorus_get_tensor_details",
+            {"dataset_name": dataset_name, "record_id": record_id},
+        )
+
+
+async def main() -> None:
+    server_path = os.path.join(os.path.dirname(__file__), "mcp_time_series_server.py")
+    transport = StdioTransport("python", [server_path])
+    async with TensorusMCPClient(transport) as client:
+        await client.create_dataset("timeseries_demo")
+        x = np.linspace(0, 2 * math.pi, 50)
+        data = np.sin(x).tolist()
+        result = await client.ingest_tensor(
+            "timeseries_demo",
+            tensor_shape=[50],
+            tensor_dtype="float32",
+            tensor_data=data,
+            metadata={"source": "synthetic_sine"},
+        )
+        record_id = result.get("record_id")
+        print("Inserted record", record_id)
+        details = await client.get_tensor_details("timeseries_demo", record_id)
+        print("Fetched tensor:", details)
+        datasets = await client.list_datasets()
+        print("Available datasets:", datasets)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/mcp_time_series_server.py
+++ b/mcp_time_series_server.py
@@ -1,0 +1,172 @@
+import argparse
+import asyncio
+import json
+import uuid
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Sequence
+
+import httpx
+from fastapi import FastAPI, HTTPException
+import uvicorn
+from fastmcp import FastMCP
+try:
+    from fastmcp.tools import TextContent
+except ImportError:  # pragma: no cover - support older fastmcp versions
+    @dataclass
+    class TextContent:
+        type: str
+        text: str
+
+# --- Minimal In-Memory Tensor Storage ---
+class EmbeddedTensorStorage:
+    def __init__(self) -> None:
+        self.datasets: Dict[str, Dict[str, Dict[str, Any]]] = {}
+
+    def create_dataset(self, name: str) -> None:
+        if name in self.datasets:
+            raise ValueError(f"Dataset {name} already exists")
+        self.datasets[name] = {}
+
+    def insert(
+        self,
+        name: str,
+        tensor: Sequence[float],
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> str:
+        if name not in self.datasets:
+            raise ValueError(f"Dataset {name} does not exist")
+        record_id = str(uuid.uuid4())
+        self.datasets[name][record_id] = {
+            "tensor": list(tensor),
+            "metadata": metadata or {},
+        }
+        return record_id
+
+    def get(self, name: str, record_id: str) -> Dict[str, Any]:
+        if name not in self.datasets or record_id not in self.datasets[name]:
+            raise KeyError("record not found")
+        return self.datasets[name][record_id]
+
+    def list_datasets(self) -> List[str]:
+        return list(self.datasets.keys())
+
+
+storage = EmbeddedTensorStorage()
+app = FastAPI(title="Tensorus Demo API")
+
+
+@app.post("/datasets/create")
+async def create_dataset(payload: Dict[str, str]):
+    name = payload.get("name")
+    if not name:
+        raise HTTPException(status_code=400, detail="name required")
+    try:
+        storage.create_dataset(name)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    return {"status": "created"}
+
+
+@app.get("/datasets")
+async def list_datasets():
+    return {"data": storage.list_datasets()}
+
+
+@app.post("/datasets/{dataset_name}/ingest")
+async def ingest_tensor(dataset_name: str, payload: Dict[str, Any]):
+    data = payload.get("data")
+    if not isinstance(data, list):
+        raise HTTPException(status_code=400, detail="data must be list")
+    record_id = storage.insert(dataset_name, data, payload.get("metadata"))
+    return {"record_id": record_id}
+
+
+@app.get("/datasets/{dataset_name}/tensors/{record_id}")
+async def get_tensor(dataset_name: str, record_id: str):
+    try:
+        return storage.get(dataset_name, record_id)
+    except KeyError:
+        raise HTTPException(status_code=404, detail="not found")
+
+
+# --- MCP Server (adapted from tensorus.mcp_server) ---
+API_BASE_URL = "http://127.0.0.1:8000"
+server = FastMCP(name="Tensorus FastMCP")
+
+
+async def _post(path: str, payload: dict) -> dict:
+    async with httpx.AsyncClient() as client:
+        response = await client.post(f"{API_BASE_URL}{path}", json=payload)
+        response.raise_for_status()
+        return response.json()
+
+
+async def _get(path: str) -> dict:
+    async with httpx.AsyncClient() as client:
+        response = await client.get(f"{API_BASE_URL}{path}")
+        response.raise_for_status()
+        return response.json()
+
+
+@server.tool()
+async def save_tensor(
+    dataset_name: str,
+    tensor_shape: Sequence[int],
+    tensor_dtype: str,
+    tensor_data: Any,
+    metadata: Optional[dict] = None,
+) -> TextContent:
+    payload = {
+        "shape": list(tensor_shape),
+        "dtype": tensor_dtype,
+        "data": tensor_data,
+        "metadata": metadata,
+    }
+    result = await _post(f"/datasets/{dataset_name}/ingest", payload)
+    return TextContent(type="text", text=json.dumps(result))
+
+
+@server.tool()
+async def get_tensor(dataset_name: str, record_id: str) -> TextContent:
+    result = await _get(f"/datasets/{dataset_name}/tensors/{record_id}")
+    return TextContent(type="text", text=json.dumps(result))
+
+
+@server.tool()
+async def execute_nql_query(query: str) -> TextContent:
+    result = await _post("/query", {"query": query})
+    return TextContent(type="text", text=json.dumps(result))
+
+
+@server.tool(name="tensorus_list_datasets")
+async def tensorus_list_datasets() -> TextContent:
+    result = await _get("/datasets")
+    return TextContent(type="text", text=json.dumps(result))
+
+
+@server.tool(name="tensorus_create_dataset")
+async def tensorus_create_dataset(dataset_name: str) -> TextContent:
+    result = await _post("/datasets/create", {"name": dataset_name})
+    return TextContent(type="text", text=json.dumps(result))
+
+
+@server.tool(name="tensorus_get_tensor_details")
+async def tensorus_get_tensor_details(dataset_name: str, record_id: str) -> TextContent:
+    result = await _get(f"/datasets/{dataset_name}/tensors/{record_id}")
+    return TextContent(type="text", text=json.dumps(result))
+
+
+async def run_servers() -> None:
+    config = uvicorn.Config(app, host="127.0.0.1", port=8000, log_level="error")
+    api_server = uvicorn.Server(config)
+    api_task = asyncio.create_task(api_server.serve())
+    mcp_task = asyncio.create_task(server.run_stdio_async())
+    await asyncio.gather(api_task, mcp_task)
+
+
+def main() -> None:
+    asyncio.run(run_servers())
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,5 @@ numpy
 transformers
 nltk
 scikit-learn
+fastmcp
+uvicorn


### PR DESCRIPTION
## Summary
- add a small time series demo using Tensorus MCP server and client
- document running steps in a new README
- list demo in main README
- update requirements

## Testing
- `pip install fastmcp --no-cache-dir`
- `pip install -q torch --extra-index-url https://download.pytorch.org/whl/cpu`
- `pip install -q pandas numpy`
- `pip install -U 'pydantic>=2.7.2' --no-cache-dir`
- `pip install -U 'fastapi>=0.110.0' --no-cache-dir`


------
https://chatgpt.com/codex/tasks/task_e_684ecb93c9648331af37279497036c52