### PR TITLE
Use Tensorus MCP client from library

### DIFF
--- a/README_mcp_time_series_demo.md
+++ b/README_mcp_time_series_demo.md
@@ -9,7 +9,7 @@ The demo uses a minimal FastAPI backend with an in-memory tensor store. The MCP 
 * Python 3.8+
 * Install dependencies:
   ```bash
-  pip install -r requirements.txt fastmcp uvicorn numpy
+  pip install -r requirements.txt fastmcp uvicorn numpy tensorus
   ```
 
 ## Running the Demo
@@ -25,4 +25,4 @@ The demo uses a minimal FastAPI backend with an in-memory tensor store. The MCP 
    python mcp_time_series_demo.py
    ```
 
-The client creates a dataset, inserts a synthetic sine wave, lists available datasets, and fetches the stored tensor via the MCP server. This illustrates how Tensorus capabilities can be accessed through the standardized MCP interface.
+The client creates a dataset, inserts a synthetic sine wave, updates its metadata and finally cleans up the stored tensor and dataset. This illustrates how Tensorus capabilities can be accessed through the standardized MCP interface.

--- a/mcp_time_series_demo.py
+++ b/mcp_time_series_demo.py
@@ -1,71 +1,10 @@
 import asyncio
-import json
 import math
 import os
-from dataclasses import dataclass
-from typing import Any, Optional, Sequence
 
 import numpy as np
-from fastmcp.client import Client as FastMCPClient, StdioTransport
-try:
-    from fastmcp.tools import TextContent
-except Exception:  # pragma: no cover - minimal fallback
-    @dataclass
-    class TextContent:  # type: ignore
-        type: str
-        text: str
-
-
-class TensorusMCPClient:
-    """High level client for the Tensorus MCP server."""
-
-    def __init__(self, transport: Any) -> None:
-        self._client = FastMCPClient(transport)
-
-    async def __aenter__(self) -> "TensorusMCPClient":
-        await self._client.__aenter__()
-        return self
-
-    async def __aexit__(self, exc_type, exc, tb) -> None:
-        await self._client.__aexit__(exc_type, exc, tb)
-
-    async def _call_json(self, name: str, arguments: Optional[dict] = None) -> Any:
-        result = await self._client.call_tool(name, arguments or {})
-        if not result:
-            return None
-        content = result[0]
-        if isinstance(content, TextContent):
-            return json.loads(content.text)
-        raise TypeError("Unexpected content type")
-
-    async def list_datasets(self) -> Any:
-        return await self._call_json("tensorus_list_datasets")
-
-    async def create_dataset(self, dataset_name: str) -> Any:
-        return await self._call_json("tensorus_create_dataset", {"dataset_name": dataset_name})
-
-    async def ingest_tensor(
-        self,
-        dataset_name: str,
-        tensor_shape: Sequence[int],
-        tensor_dtype: str,
-        tensor_data: Any,
-        metadata: Optional[dict] = None,
-    ) -> Any:
-        payload = {
-            "dataset_name": dataset_name,
-            "tensor_shape": list(tensor_shape),
-            "tensor_dtype": tensor_dtype,
-            "tensor_data": tensor_data,
-            "metadata": metadata,
-        }
-        return await self._call_json("tensorus_ingest_tensor", payload)
-
-    async def get_tensor_details(self, dataset_name: str, record_id: str) -> Any:
-        return await self._call_json(
-            "tensorus_get_tensor_details",
-            {"dataset_name": dataset_name, "record_id": record_id},
-        )
+from fastmcp.client import StdioTransport
+from tensorus.mcp_client import TensorusMCPClient
 
 
 async def main() -> None:
@@ -86,8 +25,18 @@ async def main() -> None:
         print("Inserted record", record_id)
         details = await client.get_tensor_details("timeseries_demo", record_id)
         print("Fetched tensor:", details)
+        await client.update_tensor_metadata(
+            "timeseries_demo",
+            record_id,
+            {"source": "synthetic_sine", "processed": True},
+        )
+        updated = await client.get_tensor_details("timeseries_demo", record_id)
+        print("Updated metadata:", updated)
         datasets = await client.list_datasets()
         print("Available datasets:", datasets)
+        await client.delete_tensor("timeseries_demo", record_id)
+        await client.delete_dataset("timeseries_demo")
+        print("Cleanup complete")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- use the official TensorusMCPClient from the tensorus package
- extend the time series demo to show metadata updates and clean up
- document the additional dependency

## Testing
- `python mcp_time_series_demo.py` *(fails: ImportError: `fastapi` incompatible with installed pydantic)*

------
https://chatgpt.com/codex/tasks/task_e_685046d599348331ac7aa9d02a7b9d9e