### PR TITLE
Update MCP demo requirements

### DIFF
--- a/README_mcp_time_series_demo.md
+++ b/README_mcp_time_series_demo.md
@@ -9,8 +9,9 @@ The demo uses a minimal FastAPI backend with an in-memory tensor store. The MCP 
 * Python 3.8+
 * Install dependencies:
   ```bash
-  pip install -r requirements.txt fastmcp uvicorn numpy tensorus
+  pip install -r requirements.txt
   ```
+  This installs `fastmcp>=0.2.0`, `tensorus`, `uvicorn` and other required packages.
 
 ## Running the Demo
 
@@ -18,7 +19,11 @@ The demo uses a minimal FastAPI backend with an in-memory tensor store. The MCP 
    ```bash
    python mcp_time_series_server.py
    ```
-   Leave this running in a terminal.
+   Leave this running in a terminal. Alternatively, if `tensorus` is installed,
+   you can use its packaged server:
+   ```bash
+   python -m tensorus.mcp_server
+   ```
 
 2. **Run the client demo** in another terminal:
    ```bash

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,6 @@ numpy
 transformers
 nltk
 scikit-learn
-fastmcp
+fastmcp>=0.2.0
 uvicorn
+tensorus


### PR DESCRIPTION
## Summary
- pin `fastmcp` to `>=0.2.0` and include `tensorus` in requirements
- update installation notes in the MCP time series demo README
- mention running the MCP server via the demo script or `python -m tensorus.mcp_server`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685048a89b088331943e06c8f821e11e