### PR TITLE
Add MCP endpoint demo

### DIFF
--- a/MCP_endpoint_demo/demo_site.py
+++ b/MCP_endpoint_demo/demo_site.py
@@ -1,0 +1,95 @@
+import asyncio
+import json
+import streamlit as st
+from fastmcp.client import StdioTransport
+from tensorus.mcp_client import TensorusMCPClient
+
+st.set_page_config(page_title="Tensorus MCP Endpoint Demo")
+
+# Initialize MCP client and server once per session
+if 'mcp_client' not in st.session_state:
+    transport = StdioTransport("python", ["-m", "tensorus.mcp_server"])
+    client = TensorusMCPClient(transport)
+    asyncio.run(client.__aenter__())
+    st.session_state['mcp_client'] = client
+
+client: TensorusMCPClient = st.session_state['mcp_client']
+
+st.title("Tensorus MCP Endpoint Demo")
+st.write(
+    "This simple app demonstrates how to call the Model Context Protocol "
+    "(MCP) server using the `TensorusMCPClient`. The server proxies to the "
+    "public Tensorus API at https://tensorus-core.hf.space." )
+
+# Utility to run async calls
+
+def run_async(coro):
+    return asyncio.run(coro)
+
+def show_json(label, data):
+    st.subheader(label)
+    st.json(data)
+
+st.header("Dataset Operations")
+with st.form("create_dataset"):
+    dataset_name = st.text_input("Dataset name", "demo_ds")
+    submitted = st.form_submit_button("Create dataset")
+    if submitted:
+        res = run_async(client.create_dataset(dataset_name))
+        show_json("create_dataset", res)
+        st.session_state['current_dataset'] = dataset_name
+
+if st.button("List datasets"):
+    res = run_async(client.list_datasets())
+    show_json("list_datasets", res)
+
+if st.button("Delete current dataset"):
+    ds = st.session_state.get('current_dataset')
+    if ds:
+        res = run_async(client.delete_dataset(ds))
+        show_json("delete_dataset", res)
+    else:
+        st.write("No dataset created yet")
+
+st.header("Tensor Operations")
+current_ds = st.session_state.get('current_dataset')
+if current_ds:
+    if st.button("Ingest sample tensor"):
+        data = [1.0, 2.0, 3.0]
+        res = run_async(
+            client.ingest_tensor(
+                current_ds,
+                tensor_shape=[3],
+                tensor_dtype="float32",
+                tensor_data=data,
+                metadata={"demo": True},
+            )
+        )
+        show_json("ingest_tensor", res)
+        st.session_state['record_id'] = res.get('record_id')
+
+    record_id = st.session_state.get('record_id')
+    if record_id and st.button("Get tensor details"):
+        res = run_async(client.get_tensor_details(current_ds, record_id))
+        show_json("get_tensor_details", res)
+
+    if record_id and st.button("Update tensor metadata"):
+        res = run_async(
+            client.update_tensor_metadata(
+                current_ds, record_id, {"demo": True, "updated": True}
+            )
+        )
+        show_json("update_tensor_metadata", res)
+
+    if record_id and st.button("Delete tensor"):
+        res = run_async(client.delete_tensor(current_ds, record_id))
+        show_json("delete_tensor", res)
+        st.session_state.pop('record_id', None)
+else:
+    st.info("Create a dataset first to enable tensor actions.")
+
+st.header("Service Utilities")
+if st.button("Health check"):
+    res = run_async(client.management_health_check())
+    show_json("health", res)
+

--- a/README.md
+++ b/README.md
@@ -48,6 +48,13 @@ Here's an overview of the sample applications you can explore:
 *   **Description:** Demonstrates the Tensorus MCP server and client with a simple time series dataset. The demo inserts a synthetic sine wave using MCP calls and retrieves it back.
 *   **How to Run:** See ➡️ **[README_mcp_time_series_demo.md](README_mcp_time_series_demo.md)**
 
+### 4. MCP Endpoint Demo
+
+*   **Description:** A small Streamlit page that interacts with the official
+    Tensorus MCP server. It demonstrates basic dataset and tensor operations
+    using the `TensorusMCPClient`.
+*   **How to Run:** See ➡️ **[README_MCP_endpoint_demo.md](README_MCP_endpoint_demo.md)**
+
 
 ---
 

--- a/README_MCP_endpoint_demo.md
+++ b/README_MCP_endpoint_demo.md
@@ -1,0 +1,39 @@
+# Tensorus MCP Endpoint Demo
+
+This demo provides a very small Streamlit application that showcases how the
+`TensorusMCPClient` communicates with the official Tensorus MCP server.
+The server component is started automatically via `StdioTransport` and proxies
+requests to the public API at [tensorus-core.hf.space](https://tensorus-core.hf.space).
+
+The demo lets you:
+
+* Create and list datasets
+* Ingest a small example tensor
+* Retrieve and update tensor metadata
+* Delete tensors or entire datasets
+* Perform a simple health check on the service
+
+## Prerequisites
+
+- Python 3.8+
+- Install dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Running the Demo
+
+Simply launch the Streamlit app:
+
+```bash
+streamlit run MCP_endpoint_demo/demo_site.py
+```
+
+The page will display controls for the most common MCP endpoints. Each action
+uses the `TensorusMCPClient` under the hood to call the corresponding tool
+exposed by the MCP server.
+
+For full API documentation see
+[https://tensorus-core.hf.space/docs](https://tensorus-core.hf.space/docs)
+and [https://tensorus-core.hf.space/redoc](https://tensorus-core.hf.space/redoc).


### PR DESCRIPTION
## Summary
- create Streamlit demo showing how to interact with Tensorus MCP server
- document usage in `README_MCP_endpoint_demo.md`
- mention the new demo in the main `README.md`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685071c90b7c8331973ebc1e55dbb246