### PR TITLE
Add MCP endpoint demo

### DIFF
--- a/MCP_endpoint_demo/README.md
+++ b/MCP_endpoint_demo/README.md
@@ -1,0 +1,39 @@
+# Tensorus MCP Endpoint Demo
+
+This demo provides a minimal Streamlit application for exploring the Tensorus **Model Context Protocol** (MCP) server. It illustrates how a client can interact with the server's dataset and tensor management endpoints.
+
+## Prerequisites
+
+- Python 3.8+
+- Install the repository requirements:
+  ```bash
+  pip install -r requirements.txt
+  ```
+
+## Running the Demo
+
+1. **Start the MCP server** in a separate terminal. The server proxies requests to the public Tensorus API:
+   ```bash
+   python -m tensorus.mcp_server
+   ```
+
+2. **Launch the Streamlit UI** for this demo:
+   ```bash
+   streamlit run MCP_endpoint_demo/app.py
+   ```
+
+The UI offers simple forms to call several MCP endpoints and shows the JSON responses returned by the server.
+
+## Supported Operations
+
+The app demonstrates these MCP client methods:
+
+- `list_datasets`
+- `create_dataset`
+- `delete_dataset`
+- `ingest_tensor`
+- `get_tensor_details`
+- `update_tensor_metadata`
+- `delete_tensor`
+
+Refer to the [Tensorus API documentation](https://tensorus-core.hf.space/docs) for full details on each endpoint.

--- a/MCP_endpoint_demo/app.py
+++ b/MCP_endpoint_demo/app.py
@@ -1,0 +1,100 @@
+import asyncio
+import json
+from typing import Any, List
+
+import streamlit as st
+from fastmcp.client import StdioTransport
+from tensorus.mcp_client import TensorusMCPClient
+
+
+# Utility to run a single MCP client call
+async def _call(method: str, *args: Any, **kwargs: Any) -> Any:
+    transport = StdioTransport("python", ["-m", "tensorus.mcp_server"])
+    async with TensorusMCPClient(transport) as client:
+        func = getattr(client, method)
+        return await func(*args, **kwargs)
+
+
+def run(method: str, *args: Any, **kwargs: Any) -> Any:
+    return asyncio.run(_call(method, *args, **kwargs))
+
+
+st.title("Tensorus MCP Endpoint Demo")
+
+st.markdown(
+    "This demo uses the `TensorusMCPClient` to communicate with a local MCP server"
+    " started via `python -m tensorus.mcp_server`. Use the forms below to invoke"
+    " common endpoints and inspect their JSON responses."
+)
+
+operation = st.sidebar.selectbox(
+    "Choose an operation",
+    (
+        "list_datasets",
+        "create_dataset",
+        "delete_dataset",
+        "ingest_tensor",
+        "get_tensor_details",
+        "update_tensor_metadata",
+        "delete_tensor",
+    ),
+)
+
+result: Any = None
+
+if operation == "list_datasets":
+    if st.button("List datasets"):
+        result = run("list_datasets")
+
+elif operation == "create_dataset":
+    name = st.text_input("Dataset name")
+    if st.button("Create") and name:
+        result = run("create_dataset", name)
+
+elif operation == "delete_dataset":
+    name = st.text_input("Dataset name")
+    if st.button("Delete") and name:
+        result = run("delete_dataset", name)
+
+elif operation == "ingest_tensor":
+    dataset = st.text_input("Dataset name")
+    data_str = st.text_area(
+        "Tensor data (comma separated numbers)",
+        "0.0, 1.0, 2.0",
+    )
+    metadata_str = st.text_area("Metadata JSON", "{}")
+    if st.button("Ingest") and dataset and data_str:
+        numbers: List[float] = [float(x) for x in data_str.split(",") if x.strip()]
+        metadata = json.loads(metadata_str or "{}")
+        result = run(
+            "ingest_tensor",
+            dataset,
+            [len(numbers)],
+            "float32",
+            numbers,
+            metadata,
+        )
+
+elif operation == "get_tensor_details":
+    dataset = st.text_input("Dataset name")
+    record_id = st.text_input("Record ID")
+    if st.button("Fetch") and dataset and record_id:
+        result = run("get_tensor_details", dataset, record_id)
+
+elif operation == "update_tensor_metadata":
+    dataset = st.text_input("Dataset name")
+    record_id = st.text_input("Record ID")
+    metadata_str = st.text_area("New metadata JSON", "{}")
+    if st.button("Update") and dataset and record_id:
+        metadata = json.loads(metadata_str or "{}")
+        result = run("update_tensor_metadata", dataset, record_id, metadata)
+
+elif operation == "delete_tensor":
+    dataset = st.text_input("Dataset name")
+    record_id = st.text_input("Record ID")
+    if st.button("Delete") and dataset and record_id:
+        result = run("delete_tensor", dataset, record_id)
+
+if result is not None:
+    st.subheader("Result")
+    st.json(result)

--- a/README.md
+++ b/README.md
@@ -48,6 +48,11 @@ Here's an overview of the sample applications you can explore:
 *   **Description:** Demonstrates the Tensorus MCP server and client with a simple time series dataset. The demo inserts a synthetic sine wave using MCP calls and retrieves it back.
 *   **How to Run:** See ➡️ **[README_mcp_time_series_demo.md](README_mcp_time_series_demo.md)**
 
+### 4. MCP Endpoint Demo
+
+*   **Description:** A Streamlit UI that lets you interact with the Tensorus MCP server through the `TensorusMCPClient`. It demonstrates creating datasets, ingesting tensors and fetching records using the official MCP endpoints.
+*   **How to Run:** See ➡️ **[README.md](MCP_endpoint_demo/README.md)**
+
 
 ---
 

--- a/tensorus-demo-page/src/demoData.js
+++ b/tensorus-demo-page/src/demoData.js
@@ -35,6 +35,23 @@ export const demos = [
     tags: ['NLP', 'Literature', 'Sentiment Analysis', 'Relationships'],
     localPort: 8501, // Default Streamlit port (Note: if running both simultaneously, one will take another port like 8502)
     streamlitCommand: 'streamlit run story_analyzer_demo.py'
+  },
+  {
+    id: 'mcp-endpoint-demo',
+    title: 'MCP Endpoint Demo',
+    shortDescription: 'Interactively call Tensorus MCP server endpoints.',
+    longDescription: 'A minimal Streamlit interface demonstrating the Tensorus Model Context Protocol. Users can create datasets, ingest tensors and inspect records via the MCP client.',
+    thumbnailUrl: 'https://placehold.co/600x360/FF9500/FFFFFF/png?text=MCP+Demo',
+    visualsPath: 'https://placehold.co/800x450/FF9500/FFFFFF/png?text=MCP+Endpoint+Detail',
+    keyFeatures: [
+      'Shows how to run the Tensorus MCP server.',
+      'Uses TensorusMCPClient to call dataset and tensor APIs.',
+      'Displays raw JSON responses for educational purposes.'
+    ],
+    readmeLink: 'https://github.com/GoogleCloudPlatform/tensorus/blob/main/MCP_endpoint_demo/README.md',
+    tags: ['MCP', 'API', 'Tensorus'],
+    localPort: 8501,
+    streamlitCommand: 'streamlit run MCP_endpoint_demo/app.py'
   }
   // Future demos will be added here
 ];


### PR DESCRIPTION
## Summary
- add `MCP_endpoint_demo` directory with a Streamlit app showing how to call MCP endpoints
- document how to run the demo
- register the new demo in the gallery page data
- mention the demo in the main README

## Testing
- `python -m py_compile MCP_endpoint_demo/app.py`
- `black MCP_endpoint_demo/app.py`

------
https://chatgpt.com/codex/tasks/task_e_685071c90b7c8331973ebc1e55dbb246