### PR TITLE
Add MCP endpoint demo

### DIFF
--- a/MCP_endpoint_demo/README.md
+++ b/MCP_endpoint_demo/README.md
@@ -1,0 +1,39 @@
+# Tensorus MCP Endpoint Demo
+
+This demo provides a minimal Streamlit application for exploring the Tensorus **Model Context Protocol** (MCP) server. It illustrates how a client can interact with the server's dataset and tensor management endpoints.
+
+## Prerequisites
+
+- Python 3.8+
+- Install the repository requirements:
+  ```bash
+  pip install -r requirements.txt
+  ```
+
+## Running the Demo
+
+1. **Start the MCP server** in a separate terminal. The server proxies requests to the public Tensorus API and exposes an SSE endpoint:
+   ```bash
+   python -m tensorus.mcp_server
+   ```
+
+2. **Launch the Streamlit UI** for this demo:
+   ```bash
+   streamlit run MCP_endpoint_demo/app.py
+   ```
+
+The UI offers simple forms to call several MCP endpoints. Enter the SSE URL of your running server (for example `http://127.0.0.1:8000/sse`) in the sidebar.
+
+## Supported Operations
+
+The app demonstrates these MCP client methods:
+
+- `list_datasets`
+- `create_dataset`
+- `delete_dataset`
+- `ingest_tensor`
+- `get_tensor_details`
+- `update_tensor_metadata`
+- `delete_tensor`
+
+Refer to the [Tensorus API documentation](https://tensorus-core.hf.space/docs) for full details on each endpoint.

--- a/MCP_endpoint_demo/app.py
+++ b/MCP_endpoint_demo/app.py
@@ -1,0 +1,108 @@
+import asyncio
+import json
+from typing import Any, List
+
+import streamlit as st
+from fastmcp.client import SSETransport
+from tensorus.mcp_client import TensorusMCPClient
+
+
+# Utility to run a single MCP client call via the running server
+async def _call(server_url: str, method: str, *args: Any, **kwargs: Any) -> Any:
+    transport = SSETransport(server_url)
+    async with TensorusMCPClient(transport) as client:
+        func = getattr(client, method)
+        return await func(*args, **kwargs)
+
+
+def run(server_url: str, method: str, *args: Any, **kwargs: Any) -> Any:
+    try:
+        with st.spinner("Calling MCP server..."):
+            return asyncio.run(_call(server_url, method, *args, **kwargs))
+    except Exception as exc:  # pragma: no cover - network/server errors
+        st.error(str(exc))
+        return None
+
+
+st.title("Tensorus MCP Endpoint Demo")
+
+st.markdown(
+    "This demo uses the `TensorusMCPClient` to communicate with a local MCP server."
+    " Start the server in another terminal via `python -m tensorus.mcp_server`"
+    " and point the UI to its SSE endpoint."
+)
+
+server_url = st.sidebar.text_input("MCP server SSE URL", "http://127.0.0.1:8000/sse")
+
+operation = st.sidebar.selectbox(
+    "Choose an operation",
+    (
+        "list_datasets",
+        "create_dataset",
+        "delete_dataset",
+        "ingest_tensor",
+        "get_tensor_details",
+        "update_tensor_metadata",
+        "delete_tensor",
+    ),
+)
+
+result: Any = None
+
+if operation == "list_datasets":
+    if st.button("List datasets"):
+        result = run(server_url, "list_datasets")
+
+elif operation == "create_dataset":
+    name = st.text_input("Dataset name")
+    if st.button("Create") and name:
+        result = run(server_url, "create_dataset", name)
+
+elif operation == "delete_dataset":
+    name = st.text_input("Dataset name")
+    if st.button("Delete") and name:
+        result = run(server_url, "delete_dataset", name)
+
+elif operation == "ingest_tensor":
+    dataset = st.text_input("Dataset name")
+    data_str = st.text_area(
+        "Tensor data (comma separated numbers)",
+        "0.0, 1.0, 2.0",
+    )
+    metadata_str = st.text_area("Metadata JSON", "{}")
+    if st.button("Ingest") and dataset and data_str:
+        numbers: List[float] = [float(x) for x in data_str.split(",") if x.strip()]
+        metadata = json.loads(metadata_str or "{}")
+        result = run(
+            server_url,
+            "ingest_tensor",
+            dataset,
+            [len(numbers)],
+            "float32",
+            numbers,
+            metadata,
+        )
+
+elif operation == "get_tensor_details":
+    dataset = st.text_input("Dataset name")
+    record_id = st.text_input("Record ID")
+    if st.button("Fetch") and dataset and record_id:
+        result = run(server_url, "get_tensor_details", dataset, record_id)
+
+elif operation == "update_tensor_metadata":
+    dataset = st.text_input("Dataset name")
+    record_id = st.text_input("Record ID")
+    metadata_str = st.text_area("New metadata JSON", "{}")
+    if st.button("Update") and dataset and record_id:
+        metadata = json.loads(metadata_str or "{}")
+        result = run(server_url, "update_tensor_metadata", dataset, record_id, metadata)
+
+elif operation == "delete_tensor":
+    dataset = st.text_input("Dataset name")
+    record_id = st.text_input("Record ID")
+    if st.button("Delete") and dataset and record_id:
+        result = run(server_url, "delete_tensor", dataset, record_id)
+
+if result is not None:
+    st.subheader("Result")
+    st.json(result)

--- a/README.md
+++ b/README.md
@@ -48,6 +48,11 @@ Here's an overview of the sample applications you can explore:
 *   **Description:** Demonstrates the Tensorus MCP server and client with a simple time series dataset. The demo inserts a synthetic sine wave using MCP calls and retrieves it back.
 *   **How to Run:** See ➡️ **[README_mcp_time_series_demo.md](README_mcp_time_series_demo.md)**
 
+### 4. MCP Endpoint Demo
+
+*   **Description:** A Streamlit UI that lets you interact with the Tensorus MCP server. Start the server separately and use the UI to call dataset and tensor endpoints via its SSE interface.
+*   **How to Run:** See ➡️ **[README.md](MCP_endpoint_demo/README.md)**
+
 
 ---
 

--- a/tensorus-demo-page/src/demoData.js
+++ b/tensorus-demo-page/src/demoData.js
@@ -35,6 +35,23 @@ export const demos = [
     tags: ['NLP', 'Literature', 'Sentiment Analysis', 'Relationships'],
     localPort: 8501, // Default Streamlit port (Note: if running both simultaneously, one will take another port like 8502)
     streamlitCommand: 'streamlit run story_analyzer_demo.py'
+  },
+  {
+    id: 'mcp-endpoint-demo',
+    title: 'MCP Endpoint Demo',
+    shortDescription: 'Interactively call Tensorus MCP server endpoints.',
+    longDescription: 'A minimal Streamlit interface demonstrating the Tensorus Model Context Protocol. Start the MCP server separately and point the UI to its SSE endpoint to create datasets and ingest tensors.',
+    thumbnailUrl: 'https://placehold.co/600x360/FF9500/FFFFFF/png?text=MCP+Demo',
+    visualsPath: 'https://placehold.co/800x450/FF9500/FFFFFF/png?text=MCP+Endpoint+Detail',
+    keyFeatures: [
+      'Shows how to run the Tensorus MCP server.',
+      'Uses TensorusMCPClient to call dataset and tensor APIs.',
+      'Displays raw JSON responses for educational purposes.'
+    ],
+    readmeLink: 'https://github.com/GoogleCloudPlatform/tensorus/blob/main/MCP_endpoint_demo/README.md',
+    tags: ['MCP', 'API', 'Tensorus'],
+    localPort: 8501,
+    streamlitCommand: 'streamlit run MCP_endpoint_demo/app.py'
   }
   // Future demos will be added here
 ];


### PR DESCRIPTION
## Summary
- add `MCP_endpoint_demo` directory with a Streamlit app showing how to call MCP endpoints
- document how to run the demo
- register the new demo in the gallery page data
- mention the demo in the main README
- fix SSE connection for the MCP endpoint demo

## Testing
- `black --check MCP_endpoint_demo/app.py`
- `python -m py_compile MCP_endpoint_demo/app.py`


------
https://chatgpt.com/codex/tasks/task_e_685071c90b7c8331973ebc1e55dbb246