### PR TITLE
Handle MCP operation failures

### DIFF
--- a/MCP_endpoint_demo/app.py
+++ b/MCP_endpoint_demo/app.py
@@ -16,7 +16,11 @@ async def _call(method: str, *args: Any, **kwargs: Any) -> Any:
 
 
 def run(method: str, *args: Any, **kwargs: Any) -> Any:
-    return asyncio.run(_call(method, *args, **kwargs))
+    try:
+        return asyncio.run(_call(method, *args, **kwargs))
+    except Exception as exc:
+        st.error(f"{method} failed: {exc}")
+        return None
 
 
 st.title("Tensorus MCP Endpoint Demo")

--- a/MCP_endpoint_demo/demo_site.py
+++ b/MCP_endpoint_demo/demo_site.py
@@ -24,7 +24,11 @@ st.write(
 # Utility to run async calls
 
 def run_async(coro):
-    return asyncio.run(coro)
+    try:
+        return asyncio.run(coro)
+    except Exception as exc:
+        st.error(str(exc))
+        return None
 
 def show_json(label, data):
     st.subheader(label)


### PR DESCRIPTION
## Summary
- surface MCP errors via `st.error` in `run` utility
- catch exceptions in `run_async` helper

## Testing
- `python -m py_compile MCP_endpoint_demo/app.py MCP_endpoint_demo/demo_site.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850d66a7b80833186f26d5cbf9d2401