### PR TITLE
Fix MCP endpoint demo docs

### DIFF
--- a/MCP_endpoint_demo/README.md
+++ b/MCP_endpoint_demo/README.md
@@ -12,15 +12,10 @@ This demo provides a minimal Streamlit application for exploring the Tensorus **
 
 ## Running the Demo
 
-1. **Start the MCP server** in a separate terminal. The server proxies requests to the public Tensorus API:
-   ```bash
-   python -m tensorus.mcp_server
-   ```
-
-2. **Launch the Streamlit UI** for this demo:
-   ```bash
-   streamlit run MCP_endpoint_demo/app.py
-   ```
+Simply run the Streamlit app. It automatically launches a local MCP server using `python -m tensorus.mcp_server`:
+```bash
+streamlit run MCP_endpoint_demo/app.py
+```
 
 The UI offers simple forms to call several MCP endpoints and shows the JSON responses returned by the server.
 

--- a/README_MCP_endpoint_demo.md
+++ b/README_MCP_endpoint_demo.md
@@ -24,10 +24,10 @@ pip install -r requirements.txt
 
 ## Running the Demo
 
-Simply launch the Streamlit app:
+Launch the Streamlit app (it automatically starts a local MCP server):
 
 ```bash
-streamlit run MCP_endpoint_demo/demo_site.py
+streamlit run MCP_endpoint_demo/app.py
 ```
 
 The page will display controls for the most common MCP endpoints. Each action


### PR DESCRIPTION
## Summary
- sync README_MCP_endpoint_demo docs
- clarify that the MCP server auto-starts
- remove outdated instructions to run `demo_site.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850d67ab0f883318b7b76b63f0401ba